### PR TITLE
star_cardにstarのアイコン追加

### DIFF
--- a/app/assets/stylesheets/_addiction_card.scss
+++ b/app/assets/stylesheets/_addiction_card.scss
@@ -1,0 +1,30 @@
+.addiction-card{
+  .card-main-image{
+
+  }
+  .card-left{
+    display: inline-block;
+  }
+  .card-right{
+    display: inline-block;
+    float: right;
+    h4{
+      font-weight: bold;
+      padding-bottom: 4px;
+    }
+  }
+
+  .image-icon{
+    height: 11vw;
+    width: 11vw;
+    min-height: 50px;
+    max-height: 70px;
+    min-width: 50px;
+    max-width: 70px;
+    overflow: hidden;
+    margin: 0 auto;
+    img{
+      height: 100%;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,4 +5,4 @@
 @import './config';
 @import './devise';
 @import './star_index';
-
+@import './addiction_card';

--- a/app/views/shared/_addiction_card.html.haml
+++ b/app/views/shared/_addiction_card.html.haml
@@ -2,14 +2,15 @@
   .container
     .row
       - 9.times do |i|
-        .col-md-4.col-6.pr-1.pl-1
+        .addiction-card.col-md-4.col-6.pr-1.pl-1.pb-4
           = link_to "#" do
-            .card.mb-4.box-shadow
+            .card-main-image.card.mb-4.box-shadow
               = image_tag("https://a0.muscache.com/im/pictures/19672386/3f6c4359_original.jpg?aki_policy=large",class: "card-img-top")
-              .card-body
-                %p.card-text This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.
-                .d-flex.justify-content-between.align-items-center
-                  %small.text-muted 9 mins
-                  .btn-group
-                    %button.btn.btn-sm.btn-outline-secondary{type: "button"} Link
-                    %button.btn.btn-sm.btn-outline-secondary{type: "button"} Fav
+              .card-body.p-3
+                .card-left.col-lg-3.col-sm-12.p-0
+                  .rounded-circle.image-icon
+                    = image_tag("http://an-blog.com/wp-content/uploads/2016/07/022-300x300.jpg", class: "")
+                .card-right.col-lg-9.col-sm-12.p-0
+                  .card-text.pl-2
+                    %h4 タイトルは全角で最大１５文字
+                    %p ここの欄は１００文字がいい感じに収まる。ハマっていることについて９９文字まで載せ、最後の１文字を...にする。


### PR DESCRIPTION
## WHAT
- 一覧表示のテンプレートにstarのアイコンを表示
- lgの時はアイコンが下段の左、sm(スマホ)の時はアイコンが中段の真ん中になる

- お気に入りボタンは、写真だけ見ていくつもストックするようなものではないため、star_showの画面でつける仕様にする

<img width="1449" alt="2018-07-23 15 30 05" src="https://user-images.githubusercontent.com/38639558/43060811-6c305e18-8e8d-11e8-8cc8-b977835006dc.png">
<img width="402" alt="2018-07-23 15 30 30" src="https://user-images.githubusercontent.com/38639558/43060812-6d19df2a-8e8d-11e8-9dfd-a1c796af2c35.png">
